### PR TITLE
I had some trouble finding the pyramid_formalchemy documentation, because

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,11 @@
 This module provide a set of utilities for using FormAlchemy_ with Pyramid
 
-.. _formalchemy: http://docs.formalchemy.org/formalchemy.html
+.. _formalchemy: http://docs.formalchemy.org/
 
 Have a look at the `Online demo
 <http://docs.formalchemy.org/demo/admin/>`_
+or at the `Documentation
+<http://docs.formalchemy.org/pyramid_formalchemy/>`_
 
 Bug and feature request must be reported on the `github tracker
 <https://github.com/FormAlchemy/pyramid_formalchemy/issues>`_


### PR DESCRIPTION
I had some trouble finding the pyramid_formalchemy documentation, because following the FormAlchemy link of this README, I was forwarded to the "About FormAlchemy" page which has no documentation. So one could have thought that FormAlchemy has no documentation.

Please also consider moving README.txt to README.rst so that github will be able to render it correctly.
